### PR TITLE
Adding support for *.jsx file extensions.

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -5,6 +5,7 @@
   '_js'
   'es'
   'es6'
+  'jsx'
 ]
 'firstLineMatch': '^#!.*\\b(node|iojs)'
 'name': 'JavaScript ES6'


### PR DESCRIPTION
React now supports ES6 classes, as of React 0.13, however they usually use the `*.jsx` extension (as it adds it's own set of syntax which is compiled to regular Javascript). This tiny PR should (as far as I can tell) allow the language-javascript-better plugin for Atom to support `*.jsx` files with ES6 syntax checking.
